### PR TITLE
Hide "Today's News" section from the timeline

### DIFF
--- a/src/element_hiding.js
+++ b/src/element_hiding.js
@@ -60,7 +60,13 @@
             'a[href="/i/monetization"]'
         ], st: HideType.DISPLAY},
         hide_ads_button: {s: ['a[href*="https://ads.x.com"]'], st: HideType.DISPLAY},
-        hide_todays_news: {s: ['div:has(> [data-testid="news_sidebar"])'], st: HideType.DISPLAY},
+        hide_todays_news: {s: [
+            'div:has(> [data-testid="news_sidebar"])',
+            'div:has(> div > div > button > a[href^="/explore"])',
+            'div:has(> div > div > button > a[href^="/explore"]) + div:has(> div > div > [data-testid=trend])',
+            'div:has(> div > div > [data-testid=trend]) + div:has(> div > div > :is([data-testid=trend], a[href^="/explore"]))',
+            'div:has(> div > div > [data-testid=trend]) + div:has(> div > div > a[href^="/explore"]) + div'
+        ], st: HideType.DISPLAY},
         hide_whats_happening: {s: ['div:has(> * > [aria-label="Timeline: Trending now"])'], st: HideType.DISPLAY},
         hide_who_to_follow: {s: [
             'div:has(> * > [aria-label="Who to follow"])',


### PR DESCRIPTION
<img width="643" height="408" alt="2025-12-06_141646" src="https://github.com/user-attachments/assets/749e2cf6-3388-4efd-9174-b7eed9a232de" />

This section is built from multiple different elements placed into the timeline independently. These selectors will catch:

- "Today's News" headline, which starts the section (first selector)
- News elements following this headline and each other (second & third selector)
- "Show more" button after the last news element (third selector)
- Border which is displayed after the "Show more" button (fourth selector)

Since all of them included into the timeline without one common parent, I've decided to make selectors a lot more specific just not to hide something else unexpectedly.

Also, this section is very rarely appears in the timeline. Usually I'm seeing it when I'm opening Twitter for the first time in a day. So, it would be quite hard to test. And I forgot to provide the example snippet, might send it next time I'll see this section.