### PR TITLE
Hide "Who to follow" from the timeline

### DIFF
--- a/src/element_hiding.js
+++ b/src/element_hiding.js
@@ -64,7 +64,11 @@
         hide_whats_happening: {s: ['div:has(> * > [aria-label="Timeline: Trending now"])'], st: HideType.DISPLAY},
         hide_who_to_follow: {s: [
             'div:has(> * > [aria-label="Who to follow"])',
-            'div:has(> * > * > [aria-label="Loading recommendations for users to follow"])'
+            'div:has(> * > * > [aria-label="Loading recommendations for users to follow"])',
+            'div:has(+ div > div > div > button[data-testid="UserCell"])',
+            'div:has(> div > div > button[data-testid="UserCell"])',
+            'div:has(> div > div > a[href^="/i/connect_people"])',
+            'div:has(> div > div > a[href^="/i/connect_people"]) + div',
         ], st: HideType.DISPLAY},
         hide_relevant_people: {s: ['div:has(> [aria-label="Relevant people"])'], st: HideType.DISPLAY},
         hide_create_your_space: {s: ['a[href="/i/spaces/start"]'], st: HideType.DISPLAY},


### PR DESCRIPTION
<img width="619" height="423" alt="image" src="https://github.com/user-attachments/assets/4ec266f4-b30b-4742-9926-f4329cbb87b3" />

This one is a bit easier to find, since there are links and clear IDs to catch, despite the fact they all also exist in the timeline separately from each other.

- First selector captures the "Who to follow" heading
- Second selector captures all recommended users
- Third selector captures the "Show more" button
- Fourth selector captures the border after the "Show more"

Here is markup sample to check the selectors on: https://gist.github.com/koloml/36372ed98012d2ccc8e3335679df22af